### PR TITLE
Add favourite toggle support to snippet editing

### DIFF
--- a/backend/routes.py
+++ b/backend/routes.py
@@ -32,6 +32,7 @@ class EditSnippetData(BaseModel):
     language: str
     tags: list[str] = []
     is_public: bool = False
+    favourite: bool = False
 
 
 class ChangePasswordData(BaseModel):
@@ -385,7 +386,7 @@ async def edit_snippet(
 
     Requires:
         snippet_id (int): The ID of the snippet to edit.
-        data (EditSnippetData): The updated snippet data (title, content, language, tags, is_public).
+        data (EditSnippetData): The updated snippet data (title, content, language, tags, is_public, favourite).
         user_id (int): Obtained from the JWT token.
 
     Returns:
@@ -399,6 +400,7 @@ async def edit_snippet(
         data.language,
         data.tags,
         data.is_public,
+        data.favourite,
     )
     if result["success"]:
         return result

--- a/backend/snippets.py
+++ b/backend/snippets.py
@@ -204,7 +204,7 @@ class Snippets(Database):
                     "title": self.encryptor.decrypt(title),
                     "content": self.encryptor.decrypt(content),
                     "language": self.encryptor.decrypt(language),
-                    "favourite": self.encryptor.decrypt(favourite) == "true",
+                    "favourite": favourite,  # favourite is already a boolean, no need to decrypt
                     "created_at": created_at,
                     "tags": parsed_tags,
                     "is_public": is_public if is_public is not None else False,
@@ -246,6 +246,7 @@ class Snippets(Database):
         language,
         tags=None,
         is_public=False,
+        favourite=False,
     ):
         try:
             self.cursor.execute(
@@ -264,7 +265,7 @@ class Snippets(Database):
             encrypted_tags = self.encryptor.encrypt(json_tags)
 
             self.cursor.execute(
-                "UPDATE code_snippets SET title = %s, content = %s, language = %s, tags = %s, is_public = %s "
+                "UPDATE code_snippets SET title = %s, content = %s, language = %s, tags = %s, is_public = %s, favourite = %s "
                 "WHERE id = %s AND user_id = %s",
                 (
                     self.encryptor.encrypt(new_title),
@@ -272,6 +273,7 @@ class Snippets(Database):
                     self.encryptor.encrypt(language),
                     encrypted_tags,
                     is_public,
+                    favourite,
                     snippet_id,
                     self.user_id,
                 ),

--- a/frontend/src/Components/Signup.jsx
+++ b/frontend/src/Components/Signup.jsx
@@ -40,7 +40,7 @@ function SignUp() {
             if(result.message && result.message.includes("User created successfully")){
                 setAlertMessage("Account created successfully!");
                 setTimeout(() => {
-                    navigate("/");
+                    navigate("/login");
                 }, 1500);
             }
         }catch (error){


### PR DESCRIPTION
Backend and frontend updated to support toggling the 'favourite' status of code snippets. The backend now accepts and updates the 'favourite' field, and the frontend's toggleFavorite function properly handles tags and sends the correct request body. Also, after successful signup, users are redirected to the login page instead of the home page.